### PR TITLE
Add LruCache implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
 }
 
 tasks.test {

--- a/src/main/kotlin/io/github/cachetools4k/Cache.kt
+++ b/src/main/kotlin/io/github/cachetools4k/Cache.kt
@@ -1,0 +1,53 @@
+package io.github.cachetools4k
+
+/**
+ * Represents a generic cache system capable of storing and retrieving key-value pairs.
+ *
+ * @param K The type of keys used to identify values in the cache.
+ * @param V The type of values stored in the cache.
+ */
+interface Cache<K, V> {
+    /**
+     * Retrieves a value associated with the given key from the cache.
+     *
+     * @param key The key whose associated value is to be returned.
+     * @return The value associated with the key, or null if the key is not present in the cache.
+     */
+    fun get(key: K): V?
+
+    /**
+     * Associates the specified value with the specified key in the cache.
+     *
+     * @param key The key with which the specified value is to be associated.
+     * @param value The value to be associated with the specified key.
+     */
+    fun put(key: K, value: V)
+
+    /**
+     * Removes the entry for the specified key from the cache.
+     *
+     * @param key The key whose mapping is to be removed from the cache.
+     * @return The previous value associated with the key, or null if there was no mapping.
+     */
+    fun remove(key: K): V?
+
+    /**
+     * Removes all entries from the cache, making it empty.
+     */
+    fun clear()
+
+    /**
+     * Returns the number of key-value mappings in the cache.
+     *
+     * @return The number of entries in the cache.
+     */
+    fun size(): Int
+
+    /**
+     * Checks if the cache contains a mapping for the specified key.
+     *
+     * @param key The key whose presence in the cache is to be tested.
+     * @return true if the cache contains a mapping for the specified key, false otherwise.
+     */
+    fun contains(key: K): Boolean 
+}

--- a/src/main/kotlin/io/github/cachetools4k/LruCache.kt
+++ b/src/main/kotlin/io/github/cachetools4k/LruCache.kt
@@ -11,6 +11,9 @@ package io.github.cachetools4k
  * @property maxSize The maximum number of entries the cache can hold before removing least recently used entries
  */
 class LruCache<K, V>(private val maxSize: Int): Cache<K, V> {
+    init {
+        require(maxSize > 0) { "maxSize must be positive" }
+    }
     
     private val map = object : LinkedHashMap<K, V>(16, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean {

--- a/src/main/kotlin/io/github/cachetools4k/LruCache.kt
+++ b/src/main/kotlin/io/github/cachetools4k/LruCache.kt
@@ -1,0 +1,70 @@
+package io.github.cachetools4k
+
+/**
+ * A Least Recently Used (LRU) cache implementation that automatically removes the least recently accessed entries
+ * when the cache size exceeds the specified maximum capacity.
+ *
+ * This implementation uses [LinkedHashMap] with access-order iteration to maintain the LRU order of entries.
+ *
+ * @param K The type of keys used to identify values in the cache
+ * @param V The type of values stored in the cache
+ * @property maxSize The maximum number of entries the cache can hold before removing least recently used entries
+ */
+class LruCache<K, V>(private val maxSize: Int): Cache<K, V> {
+    
+    private val map = object : LinkedHashMap<K, V>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean {
+            return size > maxSize
+        }
+    }
+
+    /**
+     * Retrieves a value associated with the given key from the cache.
+     * Accessing an entry makes it the most recently used one.
+     *
+     * @param key The key whose associated value is to be returned
+     * @return The value associated with the key, or null if the key is not present in the cache
+     */
+    override fun get(key: K): V? = map[key]
+
+    /**
+     * Associates the specified value with the specified key in the cache.
+     * If the cache reaches its size limit, the least recently used entry will be removed.
+     *
+     * @param key The key with which the specified value is to be associated
+     * @param value The value to be associated with the specified key
+     */
+    override fun put(key: K, value: V) {
+        map[key] = value
+    }
+
+    /**
+     * Removes the entry for the specified key from the cache.
+     *
+     * @param key The key whose mapping is to be removed from the cache
+     * @return The previous value associated with the key, or null if there was no mapping
+     */
+    override fun remove(key: K): V? = map.remove(key)
+
+    /**
+     * Removes all entries from the cache, making it empty.
+     */
+    override fun clear() = map.clear()
+
+    /**
+     * Returns the number of key-value mappings in the cache.
+     *
+     * @return The number of entries in the cache
+     */
+    override fun size(): Int = map.size
+
+    /**
+     * Checks if the cache contains a mapping for the specified key.
+     *
+     * @param key The key whose presence in the cache is to be tested
+     * @return true if the cache contains a mapping for the specified key, false otherwise
+     */
+    override fun contains(key: K): Boolean = map.containsKey(key)
+
+    override fun toString(): String = map.toString()
+}

--- a/src/test/kotlin/io/github/cachetools4k/LruCacheTest.kt
+++ b/src/test/kotlin/io/github/cachetools4k/LruCacheTest.kt
@@ -1,0 +1,85 @@
+package io.github.cachetools4k
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class LruCacheTest {
+
+    @Test
+    fun `test eviction of eldest entry when max size exceeded`() {
+        val cache = LruCache<String, String>(2)
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+        cache.put("key3", "value3")
+
+        assertFalse(cache.contains("key1"), "The eldest entry was not evicted correctly")
+        assertTrue(cache.contains("key2"))
+        assertTrue(cache.contains("key3"))
+    }
+
+    @Test
+    fun `test adding and retrieving elements`() {
+        val cache = LruCache<String, String>(2)
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+
+        assertEquals("value1", cache.get("key1"))
+        assertEquals("value2", cache.get("key2"))
+    }
+
+    @Test
+    fun `test removing an element`() {
+        val cache = LruCache<String, String>(2)
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+
+        assertEquals("value1", cache.remove("key1"))
+        assertNull(cache.get("key1"))
+    }
+
+    @Test
+    fun `test clearing all elements`() {
+        val cache = LruCache<String, String>(2)
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+
+        cache.clear()
+        assertEquals(0, cache.size())
+        assertFalse(cache.contains("key1"))
+        assertFalse(cache.contains("key2"))
+    }
+
+    @Test
+    fun `test cache size`() {
+        val cache = LruCache<String, String>(3)
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+        cache.put("key3", "value3")
+
+        assertEquals(3, cache.size())
+    }
+
+    @Test
+    fun `test key containment`() {
+        val cache = LruCache<String, String>(2)
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+
+        assertTrue(cache.contains("key1"))
+        assertTrue(cache.contains("key2"))
+        assertFalse(cache.contains("key3"))
+    }
+
+    @Test
+    fun `test accessing element updates its recency`() {
+        val cache = LruCache<String, String>(2)
+        cache.put("key1", "value1")
+        cache.put("key2", "value2")
+        cache.get("key1")
+        cache.put("key3", "value3")
+
+        assertTrue(cache.contains("key1"), "Recently accessed key1 should not be evicted")
+        assertFalse(cache.contains("key2"), "Least recently used key2 should be evicted")
+        assertTrue(cache.contains("key3"))
+    }
+}


### PR DESCRIPTION
Adds a generic `Cache<K, V>` interface and a concrete `LruCache<K, V>` implementation using `LinkedHashMap`. Includes unit tests for core functionality: put, get, remove, clear, eviction, and containment.